### PR TITLE
Improve AI itinerary parsing

### DIFF
--- a/TravelSmith/server/routes.ts
+++ b/TravelSmith/server/routes.ts
@@ -162,10 +162,15 @@ Provide a detailed day-by-day breakdown with morning and afternoon activities, h
       const aiResponse = openaiData.choices[0].message.content;
       console.log("AI Response received:", aiResponse);
 
-      // Try to parse the AI response as JSON, fall back to text if it fails
+      // Try to parse the AI response as JSON, removing any markdown code fences
       let parsedResponse;
       try {
-        parsedResponse = JSON.parse(aiResponse);
+        // Some models wrap JSON in ```json ... ``` or ```...``` blocks. Extract the inner JSON if present.
+        const jsonMatch =
+          aiResponse.match(/```json\s*([\s\S]*?)\s*```/) ||
+          aiResponse.match(/```\s*([\s\S]*?)\s*```/);
+        const jsonString = jsonMatch ? jsonMatch[1] : aiResponse;
+        parsedResponse = JSON.parse(jsonString);
       } catch (e) {
         parsedResponse = null;
       }


### PR DESCRIPTION
## Summary
- Handle OpenAI responses wrapped in markdown code fences when parsing trip itineraries

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a602c65f9483278fd0001971c3bdde